### PR TITLE
The code in the getOrientationDevice method was reporting "portait" (misspelling) when the device is laid down on a flat surface.

### DIFF
--- a/ios/BrewingDeviceOrientation.m
+++ b/ios/BrewingDeviceOrientation.m
@@ -18,9 +18,6 @@ RCT_EXPORT_MODULE();
     case UIDeviceOrientationPortrait:
       orientationIn = @"portrait-primary";
       break;
-    case UIDeviceOrientationPortraitUpsideDown:
-      orientationIn = @"portrait-secondary";
-      break;
     default:
       orientationIn = @"unknown";
       break;

--- a/ios/BrewingDeviceOrientation.m
+++ b/ios/BrewingDeviceOrientation.m
@@ -6,7 +6,6 @@ RCT_EXPORT_MODULE();
 
 - (NSString *) getOrientationDevice{
   // grab the device orientation so we can pass it back to the js side.
-  NSString *orientation;
   NSString* orientationIn;
   
   switch ([[UIDevice currentDevice] orientation]) {
@@ -23,14 +22,9 @@ RCT_EXPORT_MODULE();
       orientationIn = @"portrait-secondary";
       break;
     default:
-      orientationIn = @"portait";
+      orientationIn = @"unknown";
       break;
   }
-  
-  if ([orientationIn isEqual: @"unlocked"]) {
-    orientationIn = orientation;
-  }
-  
   return orientationIn;
 }
 


### PR DESCRIPTION
The code in the getOrientationDevice method was reporting "portait" (misspelling) when the device is laid down on a flat surface. It should return "unknown" to make it clear to developers using the component that this value is not an orientation change.

Other developers' app JS code should only check for "portrait" or "landscape", ignoring all other values.

Also removed other unnecessary code from the method.
